### PR TITLE
remove uneeded if(Meteor.isServer)

### DIFF
--- a/server/fsCollectionsServer.js
+++ b/server/fsCollectionsServer.js
@@ -1,5 +1,3 @@
-if(Meteor.isServer){
-	Images = new FS.Collection("images",{
-		stores:[new FS.Store.FileSystem("images",{})]
-	});
-}
+Images = new FS.Collection("images",{
+	stores:[new FS.Store.FileSystem("images",{})]
+});


### PR DESCRIPTION
As the file is in a "server" folder it will not be loaded on the client so we don't need to check if we are on the server.
